### PR TITLE
fix(order-form): adds target to arguments for setOrderItem and setQu…

### DIFF
--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 


### PR DESCRIPTION
…antity in menuItemChosen and menuQuantityChosen functions. Fixes challenge task #1

## Changes
1. added target property to arguments for setOrderItem and setQuantity inside menuItemChosen and menuQuanitityChosen functions.

## Purpose
The order form submit action was not working due to the target property of the events not being specified

## Approach
The menuItemChosen and menuQuantityChosen functions are being used for the onChange events in the form menu select elements to set the state of the orderItem and quantity when selecting options. Before these changes, the orderItem and quantity were being set to the event.value without specifying the target property of the event. This gives a reference to the object onto which the event was dispatched.
[(https://github.com/Shift3/react-challenge-project-sep-trial/issues/1)](url)

## Testing Steps
Open the app, select some orders and quantities in the order form and submit, then open View Orders tab to see your orders were placed.

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #1: Intentional Bug: Order form submit doesn't work
