### PR TITLE
fix(ordersList): Fixes time of order to display correctly as hh:mm:ss

### DIFF
--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {convertUnixtoHHMMSS} from '../../../src/utils/timeFormat'
 
 const OrdersList = (props) => {
     const { orders } = props;
@@ -17,7 +18,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {convertUnixtoHHMMSS(createdDate)}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">

--- a/application/src/utils/timeFormat.js
+++ b/application/src/utils/timeFormat.js
@@ -1,0 +1,8 @@
+
+export const convertUnixtoHHMMSS = (date) => {
+    const hours = `${date.getHours()}`.padStart(2, '0');
+    const minutes = `${date.getMinutes()}`.padStart(2, '0');
+    const seconds = `${date.getSeconds()}`.padStart(2, '0');
+
+    return `${hours}:${minutes}:${seconds}`;
+}


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Made utility folder and timeFormat file within to create function that returns date object in hh:mm:ss format
2. used this function in ordersList component to convert createdDate to correct format

## Purpose
When submitting an order, if order was placed at a time with less than 10 min or 10 seconds, the time would not have a 0 before min or secs. Time was displayed as 12:4:8 instead of 12:04:08 for example.

## Approach
Using JS string.padStart method with (2, '0') as arguments and applying it to the hours, minutes, and seconds makes the target length of the string 2 digits, and 'pads' the start with a 0 if it is less than 10. 
Using a utility function separates the logic to convert the time string from the component itself and could be used elsewhere in the app if needed later.

## Testing Steps
Submit an order when the time has less than 10 mins or 10 seconds and check if order placed at value is formatted in hh:mm:ss

## Learning
[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart](url)
[https://www.geeksforgeeks.org/how-to-convert-seconds-to-time-string-format-hhmmss-using-javascript/](url)

Closes #2 Bug: Order Time does not format time correctly
