### PR TITLE
test(ordersList.test): adds test to check that order times are in hh:mm:ss format

### DIFF
--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {convertUnixtoHHMMSS} from '../../../src/utils/timeFormat'
 
 const OrdersList = (props) => {
     const { orders } = props;
@@ -17,7 +18,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {convertUnixtoHHMMSS(createdDate)}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">

--- a/application/src/components/view-orders-hook/ordersList.test.js
+++ b/application/src/components/view-orders-hook/ordersList.test.js
@@ -55,4 +55,30 @@ describe('Orders List', () => {
         expect(screen.getByText(/^.*888.*$/gm)).toBeInTheDocument();
 
     });
+
+    test('renders orders with hh:mm:ss time format', () => {
+        const orders = [
+            {
+                order_item: "Food",
+                quantity: "777",
+                _id: 1,
+                createdAt: "2021-10-19T23:01:08.000Z" // this is iso 8601 format of 16:01:08
+            },
+            {
+                order_item: "Food",
+                quantity: "888",
+                _id: 2,
+                createdAt: "2021-10-19T21:03:04.000Z"
+            }
+        ];
+        render(
+            <OrdersList
+                orders={orders}
+            />
+        )
+        expect(screen.getByText(/^.*16:01:08.*$/gm)).toBeInTheDocument(); // formatted time of orders.createdAt
+        expect(screen.getByText(/^.*14:03:04.*$/gm)).toBeInTheDocument(); // formatted time of orders.createdAt
+        expect(screen.getByText(/^.*777.*$/gm)).toBeInTheDocument();
+        expect(screen.getByText(/^.*888.*$/gm)).toBeInTheDocument();
+    });
 })

--- a/application/src/utils/timeFormat.js
+++ b/application/src/utils/timeFormat.js
@@ -1,0 +1,8 @@
+
+export const convertUnixtoHHMMSS = (date) => {
+    const hours = `${date.getHours()}`.padStart(2, '0');
+    const minutes = `${date.getMinutes()}`.padStart(2, '0');
+    const seconds = `${date.getSeconds()}`.padStart(2, '0');
+
+    return `${hours}:${minutes}:${seconds}`;
+}


### PR DESCRIPTION
## Changes
Adds test to ordersList.test.js to check that orders rendered in ordersList component contain time (createdAt) in hh:mm:ss

## Purpose
The previous task was to pad times that had hours, mins, or secs less that 10 with a 0 to always have hh:mm:ss format.
ordersList.test did not have a test written to check this 

## Approach
After console logging createdDate in orderList.js, it logged the times in Wed Oct 20 2021 11:12:29 GMT-0700 (Pacific Daylight Time) format. So I thought that entering a time value for createdAt should look as so. However, in the test logs, it had the time logged in iso 8601 format. So I tried that and used screen.getByText for the time that was in the html, and it was a success. I then added another order with a different time and that succeeded as well.

## Testing Steps
Run tests on application and check for "renders orders with hh:mm:ss time format" test to pass
