### PR TITLE
fix(authReducer): fixes issue of getting user email from redux to include in order form

### DIFF
--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {convertUnixtoHHMMSS} from '../../../src/utils/timeFormat'
 
 const OrdersList = (props) => {
     const { orders } = props;
@@ -17,7 +18,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {convertUnixtoHHMMSS(createdDate)}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:

--- a/application/src/utils/timeFormat.js
+++ b/application/src/utils/timeFormat.js
@@ -1,0 +1,8 @@
+
+export const convertUnixtoHHMMSS = (date) => {
+    const hours = `${date.getHours()}`.padStart(2, '0');
+    const minutes = `${date.getMinutes()}`.padStart(2, '0');
+    const seconds = `${date.getSeconds()}`.padStart(2, '0');
+
+    return `${hours}:${minutes}:${seconds}`;
+}


### PR DESCRIPTION
## Changes
in authReducer, changed payload.login to payload.email to correctly set state and obtain user email

## Purpose
the LOGIN case in the authReducer was setting email to action.payload.login. login is not included in the payload for this action, however email is and will return the object correctly to set user email

## Approach
I looked at the authReducer and saw that email was being set to action.payload.login, then I checked the finishLogin action in authActions to find the payload includes email and token, and not login. 

## Testing Steps
Login with an email and place an order, then check that the email you logged in with is included in that order
