### PR TITLE
feat(route-guarding): adds protected route checking for auth token

### DIFF
--- a/application/src/components/login/login-form/loginForm.js
+++ b/application/src/components/login/login-form/loginForm.js
@@ -17,7 +17,6 @@ class LoginForm extends Component {
   login(e) {
     e.preventDefault();
     this.props.commenceLogin(this.state.email, this.state.password);
-    this.props.onLogin();
   }
 
   onChange(key, val) {

--- a/application/src/components/login/login.js
+++ b/application/src/components/login/login.js
@@ -1,19 +1,25 @@
-import React, { Component } from 'react';
+import React, {useEffect} from 'react';
 import LoginForm from './login-form/loginForm';
 import './login.css';
+import { useSelector } from "react-redux"
 
-class Login extends Component {
-  
-  render() {
+const Login = (props) => {
+  const token = useSelector(state => state.auth.token);
+
+  useEffect(() => {
+    if (token) {
+      props.history.push("/view-orders")
+    }
+  }, [token])
+
     return (
       <div className="main-body">
         <h1 className="text-center">Login Screen</h1>
         <div className="d-flex justify-content-center mt-5">
-          <LoginForm onLogin={() => {this.props.history.push('/view-orders')}}/>
+          <LoginForm />
         </div>
       </div>
     )
-  }
 }
 
 export default Login;

--- a/application/src/components/nav/nav.js
+++ b/application/src/components/nav/nav.js
@@ -1,8 +1,11 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import "./nav.css";
+import { useDispatch } from "react-redux";
+import { logoutUser } from "../../redux/actions/authActions"
 
 const Nav = (props) => {
+    const dispatch = useDispatch()
     return (
         <div className="nav-strip">
             <Link to={"/order"} className="nav-link">
@@ -15,7 +18,7 @@ const Nav = (props) => {
                     <label className="nav-label">View Orders</label>
                 </div>
             </Link>
-            <Link to={"/login"} className="nav-link">
+            <Link to={"/login"} onClick={() => dispatch(logoutUser())} className="nav-link">
                 <div className="nav-link-style">
                     <label className="nav-label">Log Out</label>
                 </div>

--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {convertUnixtoHHMMSS} from '../../../src/utils/timeFormat'
 
 const OrdersList = (props) => {
     const { orders } = props;
@@ -17,7 +18,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {convertUnixtoHHMMSS(createdDate)}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:

--- a/application/src/redux/store.js
+++ b/application/src/redux/store.js
@@ -1,7 +1,11 @@
-import { createStore, applyMiddleware } from 'redux';
-import ReduxThunk from 'redux-thunk';
-import reducers from './reducers';
-
-const store = createStore(reducers, {}, applyMiddleware(ReduxThunk));
-
+import { createStore, applyMiddleware, compose } from "redux";
+import ReduxThunk from "redux-thunk";
+import reducers from "./reducers";
+const store = createStore(
+  reducers, {},
+  compose(
+    applyMiddleware(ReduxThunk),
+    window.devToolsExtension ? window.devToolsExtension() : (f) => f
+  )
+);
 export default store;

--- a/application/src/router/appRouter.js
+++ b/application/src/router/appRouter.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Main, Login, OrderFormHook, ViewOrdersHook } from '../components';
+import ProtectedRoute from "../router/route-guarding/ProtectedRoute"
 
 const AppRouter = (props) => {
   return (
     <Router>
       <Route path="/" exact component={Main} />
       <Route path="/login" exact component={Login} />
-      <Route path="/order" exact component={OrderFormHook} />
-      <Route path="/view-orders" exact component={ViewOrdersHook} />
+      <ProtectedRoute path="/order" exact component={OrderFormHook} />
+      <ProtectedRoute path="/view-orders" exact component={ViewOrdersHook} />
     </Router>
   );
 }

--- a/application/src/router/route-guarding/ProtectedRoute.js
+++ b/application/src/router/route-guarding/ProtectedRoute.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useSelector } from "react-redux"
+import { Route, Redirect } from 'react-router-dom';
+
+const ProtectedRoute = ({ component: Component, ...rest }) => {
+    const token = useSelector(state => state.auth.token)
+    return (
+        <Route { ...rest }>
+            { token 
+                ? <Component />
+                : <Redirect to={"/login"} />
+            }
+        </Route>
+    )
+}
+
+export default ProtectedRoute

--- a/application/src/utils/timeFormat.js
+++ b/application/src/utils/timeFormat.js
@@ -1,0 +1,8 @@
+
+export const convertUnixtoHHMMSS = (date) => {
+    const hours = `${date.getHours()}`.padStart(2, '0');
+    const minutes = `${date.getMinutes()}`.padStart(2, '0');
+    const seconds = `${date.getSeconds()}`.padStart(2, '0');
+
+    return `${hours}:${minutes}:${seconds}`;
+}


### PR DESCRIPTION
## Changes
1. Adds a ProtectedRoute component that checks for auth token to guard /order and /view-orders routes
2. Changed Login to functional component which now checks for auth token before redirecting to /view-orders
3. takes out onLogin prop sent to LoginForm as it is no longer needed

## Purpose
The ProtectedRoute prevents users from navigating to /view-orders and /orders routes without logging in

## Approach
Addresses problem by checking for the auth token before allowing access to guarded routes. Before, the onLogin prop passed to LoginForm simply directed the user to the /view-orders page with no check for log in

## Testing Steps
try clicking login without filling out email and password or enter /view-orders or /order in url without logging in

Closes #6 Feature Request: Route Guarding
